### PR TITLE
👤 Hiển thị full name thay vì email trong greeting message

### DIFF
--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -10,9 +10,26 @@ export async function AuthButton() {
     data: { user },
   } = await supabase.auth.getUser();
 
+  let displayName = user?.email?.slice(0, 4) || '';
+
+  if (user) {
+    // Try to get user profile for full name
+    const { data: profile } = await supabase
+      .from('users')
+      .select('full_name')
+      .eq('id', user.id)
+      .single();
+
+    if (profile?.full_name && profile.full_name.trim()) {
+      displayName = profile.full_name;
+    } else {
+      displayName = user.email?.slice(0, 4) || '';
+    }
+  }
+
   return user ? (
     <div className="flex items-center gap-4">
-      Xin chào, {user.email?.slice(0, 4)}!
+      Xin chào, {displayName}!
       <LogoutButton />
     </div>
   ) : (

--- a/components/client-auth-button.tsx
+++ b/components/client-auth-button.tsx
@@ -6,25 +6,45 @@ import { Button } from "./ui/button";
 import { createClient } from "@/lib/supabase/client";
 import type { User } from "@supabase/supabase-js";
 
+interface UserProfile {
+  full_name: string | null;
+}
+
 export function ClientAuthButton() {
   const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const supabase = createClient();
-    
-    // Get initial user
-    supabase.auth.getUser().then(({ data: { user } }) => {
+
+    const fetchUserAndProfile = async (user: User | null) => {
+      if (user) {
+        // Get user profile
+        const { data: profileData } = await supabase
+          .from('users')
+          .select('full_name')
+          .eq('id', user.id)
+          .single();
+
+        setProfile(profileData);
+      } else {
+        setProfile(null);
+      }
       setUser(user);
       setLoading(false);
+    };
+
+    // Get initial user
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      fetchUserAndProfile(user);
     });
 
     // Listen for auth changes
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-      setLoading(false);
+      fetchUserAndProfile(session?.user ?? null);
     });
 
     return () => subscription.unsubscribe();
@@ -41,13 +61,20 @@ export function ClientAuthButton() {
     );
   }
 
+  const getDisplayName = () => {
+    if (profile?.full_name && profile.full_name.trim()) {
+      return profile.full_name;
+    }
+    return user?.email?.slice(0, 10) + '...' || '';
+  };
+
   return user ? (
     <div className="flex items-center gap-4">
       <span className="text-sm text-gray-600">
-        Xin chào, {user.email?.slice(0, 10)}...
+        Xin chào, {getDisplayName()}
       </span>
-      <Button 
-        size="sm" 
+      <Button
+        size="sm"
         variant="outline"
         onClick={handleSignOut}
       >


### PR DESCRIPTION
## 📋 Mô tả

Cải thiện trải nghiệm người dùng bằng cách hiển thị tên đầy đủ (full name) thay vì email trong các greeting message trên toàn ứng dụng.

## 🔧 Các thay đổi

### 1. `components/auth-button.tsx` (Server Component)
- ✅ Thêm logic lấy user profile từ database
- ✅ Hiển thị `full_name` nếu có sẵn
- ✅ Fallback về email (4 ký tự đầu) nếu không có full name
- ✅ Xử lý trường hợp full name rỗng hoặc chỉ có khoảng trắng

### 2. `components/client-auth-button.tsx` (Client Component)
- ✅ Thêm state `profile` để lưu thông tin user profile
- ✅ Thêm interface `UserProfile` cho type safety
- ✅ Cập nhật `useEffect` để lấy profile data khi user thay đổi
- ✅ Thêm function `getDisplayName()` để xác định tên hiển thị
- ✅ Hiển thị full name hoặc fallback về email

## 📊 Logic hiển thị

```typescript
// Ưu tiên hiển thị full name
if (profile?.full_name && profile.full_name.trim()) {
  displayName = profile.full_name
} else {
  // Fallback về email
  displayName = user.email?.slice(0, 4) // hoặc slice(0, 10)
}
```

## 🎨 Trải nghiệm người dùng

### Trước:
- "Xin chào, buit!" (AuthButton)
- "Xin chào, buithu.ktm..." (ClientAuthButton)
- "Xin chào, Nguyễn Văn A" (Dashboard - đã có sẵn)

### Sau:
- "Xin chào, Nguyễn Văn A!" (AuthButton)
- "Xin chào, Nguyễn Văn A" (ClientAuthButton)
- "Xin chào, Nguyễn Văn A" (Dashboard - giữ nguyên)

## 🛡️ Xử lý Edge Cases

1. **Full name rỗng**: Fallback về email
2. **Full name chỉ có khoảng trắng**: Sử dụng `trim()` để kiểm tra
3. **Không có profile data**: Fallback về email
4. **User chưa đăng nhập**: Hiển thị nút đăng nhập/đăng ký
5. **Loading state**: Hiển thị skeleton loader

## 💾 Database Integration

- Sử dụng query `SELECT full_name FROM users WHERE id = user.id`
- Không ảnh hưởng đến performance vì chỉ lấy 1 trường
- Tương thích với cả OAuth và email signup

## ✅ Test Cases

### 1. User có full name:
- **Input**: `full_name = "Nguyễn Văn A"`
- **Output**: "Xin chào, Nguyễn Văn A"

### 2. User không có full name:
- **Input**: `full_name = null` hoặc `""`
- **Output**: "Xin chào, buit!" (AuthButton) / "Xin chào, buithu.ktm..." (ClientAuthButton)

### 3. User chưa đăng nhập:
- **Output**: Hiển thị nút "Đăng nhập" và "Đăng ký"

## 🔗 Liên quan

Closes #18

## 📝 Checklist

- [x] AuthButton hiển thị full name chính xác
- [x] ClientAuthButton hiển thị full name chính xác
- [x] Fallback logic hoạt động đúng
- [x] Xử lý edge cases
- [x] Không ảnh hưởng đến performance
- [x] Tương thích với cả server và client components
- [x] Type safety với TypeScript