### PR TITLE
fix: Sửa tiền tệ từ đồng VN (₫) sang yên Nhật (¥)

### DIFF
--- a/components/admin/admin-payments.tsx
+++ b/components/admin/admin-payments.tsx
@@ -94,7 +94,7 @@ export function AdminPayments() {
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
-                {paymentStats.totalReceived.toLocaleString('vi-VN')}₫
+                ¥{paymentStats.totalReceived.toLocaleString()}
               </div>
               <p className="text-xs text-muted-foreground">
                 Đã xác nhận
@@ -173,7 +173,7 @@ export function AdminPayments() {
                     <div>
                       <h4 className="font-medium">{request.user?.full_name || request.account_holder_name}</h4>
                       <p className="text-sm text-muted-foreground">
-                        Số tiền: {request.refund_amount.toLocaleString('vi-VN')}₫
+                        Số tiền: ¥{request.refund_amount.toLocaleString()}
                       </p>
                     </div>
                     <Badge 

--- a/components/admin/event-config-manager.tsx
+++ b/components/admin/event-config-manager.tsx
@@ -256,7 +256,7 @@ export function EventConfigManager({ currentUserRole }: EventConfigManagerProps)
 
                       <div className="flex items-center gap-2">
                         <DollarSign className="h-4 w-4 text-green-500" />
-                        <span>{event.base_price.toLocaleString('vi-VN')} ¥</span>
+                        <span>¥{event.base_price.toLocaleString()}</span>
                       </div>
 
                       <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
## 🐛 Vấn đề

Hiện tại trong dự án có một số chỗ đang hiển thị tiền tệ bằng đồng VN (₫) thay vì yên Nhật (¥), không phù hợp với bối cảnh sự kiện diễn ra tại Nhật Bản.

## 🔧 Thay đổi

### Files được sửa:

#### 1. `components/admin/admin-payments.tsx`
- ✅ `{paymentStats.totalReceived.toLocaleString('vi-VN')}₫` → `¥{paymentStats.totalReceived.toLocaleString()}`
- ✅ `{request.refund_amount.toLocaleString('vi-VN')}₫` → `¥{request.refund_amount.toLocaleString()}`

#### 2. `components/admin/event-config-manager.tsx`
- ✅ `{event.base_price.toLocaleString('vi-VN')} ¥` → `¥{event.base_price.toLocaleString()}`

### KHÔNG thay đổi:
- ❌ Định dạng ngày tháng (giữ nguyên 'vi-VN')
- ❌ Các locale khác không liên quan đến tiền tệ
- ❌ Logic xử lý hoặc tính toán tiền

## 💡 Kết quả

### Trước:
```
123,456₫
123,456 ¥
```

### Sau:
```
¥123,456
```

## ✅ Testing

- ✅ Build thành công không có lỗi
- ✅ Tất cả số tiền hiển thị với ký hiệu ¥ ở đầu
- ✅ Không có ký hiệu ₫ nào còn sót lại
- ✅ Các định dạng ngày tháng không bị ảnh hưởng
- ✅ Logic tính toán tiền không thay đổi

## 🔗 Related

Closes #45

---

**Ready for review** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author