### PR TITLE
Fix: Display Facebook link in team members list

### DIFF
--- a/components/admin/teams/manage-team-members-modal.tsx
+++ b/components/admin/teams/manage-team-members-modal.tsx
@@ -54,7 +54,7 @@ interface TeamMember {
   diocese: string;
   email?: string;
   phone?: string;
-  facebook_url?: string;
+  facebook_link?: string;
   registration: {
     id: string;
     invoice_code?: string;
@@ -170,7 +170,7 @@ export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: 
       diocese: confirmAddMember.diocese,
       email: confirmAddMember.email,
       phone: confirmAddMember.phone,
-      facebook_url: undefined,
+      facebook_link: undefined,
       registration: {
         id: `temp-${confirmAddMember.id}`,
         user: {
@@ -381,9 +381,9 @@ export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: 
                           {member.registration.invoice_code}
                         </div>
                       )}
-                      {member.facebook_url && (
+                      {member.facebook_link && (
                         <div className="text-xs text-blue-600 truncate">
-                          <a href={member.facebook_url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                          <a href={member.facebook_link} target="_blank" rel="noopener noreferrer" className="hover:underline">
                             Facebook
                           </a>
                         </div>

--- a/components/admin/teams/team-detail-modal.tsx
+++ b/components/admin/teams/team-detail-modal.tsx
@@ -29,6 +29,7 @@ interface TeamMember {
   diocese?: string;
   email?: string;
   phone?: string;
+  facebook_link?: string;
   registration?: {
     id: string;
     status: string;
@@ -354,7 +355,7 @@ export function TeamDetailModal({ teamId, isOpen, onClose }: TeamDetailModalProp
                         </div>
 
                         {/* Contact Info */}
-                        {(member.email || member.phone) && (
+                        {(member.email || member.phone || member.facebook_link) && (
                           <div className="flex flex-wrap gap-4 text-sm">
                             {member.email && (
                               <div className="flex items-center gap-1 text-muted-foreground">
@@ -366,6 +367,19 @@ export function TeamDetailModal({ teamId, isOpen, onClose }: TeamDetailModalProp
                               <div className="flex items-center gap-1 text-muted-foreground">
                                 <Phone className="h-3 w-3" />
                                 <span>{member.phone}</span>
+                              </div>
+                            )}
+                            {member.facebook_link && (
+                              <div className="flex items-center gap-1 text-muted-foreground">
+                                <span className="text-blue-600">📘</span>
+                                <a
+                                  href={member.facebook_link}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-blue-600 hover:underline"
+                                >
+                                  Facebook
+                                </a>
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## Mô tả

Sửa lỗi hiển thị Facebook link trong danh sách thành viên của đội theo yêu cầu trong issue #175.

## Vấn đề đã sửa

### 1. Mismatch field name trong manage-team-members-modal.tsx
- **Vấn đề**: Interface TeamMember sử dụng facebook_url thay vì facebook_link
- **Nguyên nhân**: Database lưu trữ field registrants.facebook_link nhưng component sử dụng facebook_url
- **Sửa**: Thay đổi interface và logic hiển thị từ facebook_url thành facebook_link

### 2. Thêm Facebook link vào team-detail-modal.tsx
- **Cải tiến**: Thêm field facebook_link vào interface TeamMember
- **Hiển thị**: Thêm Facebook link vào phần contact info cùng với email và phone
- **UI**: Sử dụng icon 📘 và link Facebook với style nhất quán

## Files đã sửa

### components/admin/teams/manage-team-members-modal.tsx
- Sửa interface TeamMember: facebook_url → facebook_link
- Sửa logic hiển thị: member.facebook_url → member.facebook_link
- Sửa optimistic update: facebook_url: undefined → facebook_link: undefined

### components/admin/teams/team-detail-modal.tsx
- Thêm field facebook_link vào interface TeamMember
- Thêm hiển thị Facebook link trong phần contact info
- Sử dụng icon 📘 và link style nhất quán

## Test Results

✅ **Manage Team Members Modal**:
- Facebook link hiển thị đúng trong danh sách thành viên
- Link có thể click và mở trong tab mới
- Hiển thị Facebook với URL đúng

✅ **Team Detail Modal**:
- Facebook link hiển thị trong phần contact info
- Có icon 📘 và text Facebook
- Layout đẹp và nhất quán với email/phone

✅ **Build & Lint**:
- npm run lint: Passed (chỉ có warnings không liên quan)
- npm run build: Passed

## Trước và sau khi sửa

**Trước**: Facebook link không hiển thị trong danh sách thành viên đội
**Sau**: Facebook link hiển thị đầy đủ trong cả 2 modal quản lý thành viên và chi tiết đội

Closes #175