### PR TITLE
Feature: Display Facebook URL details instead of generic text

### DIFF
--- a/components/admin/teams/manage-team-members-modal.tsx
+++ b/components/admin/teams/manage-team-members-modal.tsx
@@ -37,6 +37,26 @@ const formatAgeGroup = (ageGroup: string): string => {
   return ageGroupMap[ageGroup] || ageGroup;
 };
 
+// Format Facebook URL for display
+const formatFacebookUrl = (url: string): string => {
+  try {
+    const urlObj = new URL(url);
+    // Remove protocol and www for cleaner display
+    let displayUrl = urlObj.hostname + urlObj.pathname;
+    if (displayUrl.startsWith('www.')) {
+      displayUrl = displayUrl.substring(4);
+    }
+    // Truncate if too long
+    if (displayUrl.length > 30) {
+      displayUrl = displayUrl.substring(0, 27) + '...';
+    }
+    return displayUrl;
+  } catch {
+    // If URL is invalid, just truncate the original
+    return url.length > 30 ? url.substring(0, 27) + '...' : url;
+  }
+};
+
 interface Team {
   id: string;
   name: string;
@@ -383,8 +403,8 @@ export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: 
                       )}
                       {member.facebook_link && (
                         <div className="text-xs text-blue-600 truncate">
-                          <a href={member.facebook_link} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                            Facebook
+                          <a href={member.facebook_link} target="_blank" rel="noopener noreferrer" className="hover:underline" title={member.facebook_link}>
+                            {formatFacebookUrl(member.facebook_link)}
                           </a>
                         </div>
                       )}

--- a/components/admin/teams/team-detail-modal.tsx
+++ b/components/admin/teams/team-detail-modal.tsx
@@ -20,6 +20,26 @@ import {
 import { formatAgeGroup, formatGender } from "@/lib/utils";
 import { RoleBadgeCompact } from "@/components/ui/role-badge";
 
+// Format Facebook URL for display
+const formatFacebookUrl = (url: string): string => {
+  try {
+    const urlObj = new URL(url);
+    // Remove protocol and www for cleaner display
+    let displayUrl = urlObj.hostname + urlObj.pathname;
+    if (displayUrl.startsWith('www.')) {
+      displayUrl = displayUrl.substring(4);
+    }
+    // Truncate if too long
+    if (displayUrl.length > 35) {
+      displayUrl = displayUrl.substring(0, 32) + '...';
+    }
+    return displayUrl;
+  } catch {
+    // If URL is invalid, just truncate the original
+    return url.length > 35 ? url.substring(0, 32) + '...' : url;
+  }
+};
+
 interface TeamMember {
   id: string;
   full_name: string;
@@ -377,8 +397,9 @@ export function TeamDetailModal({ teamId, isOpen, onClose }: TeamDetailModalProp
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="text-blue-600 hover:underline"
+                                  title={member.facebook_link}
                                 >
-                                  Facebook
+                                  {formatFacebookUrl(member.facebook_link)}
                                 </a>
                               </div>
                             )}


### PR DESCRIPTION
## Mô tả

Cải tiến hiển thị Facebook link trong danh sách thành viên đội từ text generic 'Facebook' thành URL chi tiết để dễ nhận biết và sao chép.

## Vấn đề trước đây

- Facebook link chỉ hiển thị text 'Facebook' 
- User không thể thấy URL đầy đủ để nhận biết hoặc sao chép
- Khó phân biệt các Facebook link khác nhau

## Giải pháp

### 1. Tạo utility function formatFacebookUrl()
- Loại bỏ protocol và www để hiển thị gọn gàng
- Truncate URL dài (>30 ký tự cho manage modal, >35 ký tự cho detail modal)
- Xử lý URL không hợp lệ một cách graceful

### 2. Cập nhật manage-team-members-modal.tsx
- Thêm function formatFacebookUrl()
- Hiển thị URL thay vì text 'Facebook'
- Thêm tooltip với URL đầy đủ qua attribute title

### 3. Cập nhật team-detail-modal.tsx  
- Thêm function formatFacebookUrl()
- Hiển thị URL thay vì text 'Facebook'
- Thêm tooltip với URL đầy đủ qua attribute title
- Giữ nguyên icon 📘 và style nhất quán

## Kết quả

### Trước:
- 'Facebook' (generic text)

### Sau:
- 'facebook.com/anvietcenter' (URL chi tiết)
- 'fb.com/' (URL ngắn)
- Tooltip hiển thị URL đầy đủ khi hover

## Test Results

✅ **Manage Team Members Modal**:
- Facebook URL hiển thị chi tiết: 'facebook.com/anvietcenter', 'fb.com/'
- Tooltip hiển thị URL đầy đủ khi hover
- Link có thể click và mở trong tab mới
- Truncate URL dài đúng cách

✅ **Team Detail Modal**:
- Facebook URL hiển thị chi tiết với icon 📘
- Tooltip hiển thị URL đầy đủ khi hover  
- Layout đẹp và nhất quán với email/phone
- Truncate URL dài đúng cách

✅ **UX & Responsive**:
- Layout không vỡ với URL dài
- Responsive design hoạt động tốt
- Style nhất quán giữa các modal

✅ **Build & Lint**:
- npm run lint: Passed (chỉ có warnings không liên quan)
- npm run build: Passed

## Files đã sửa

### components/admin/teams/manage-team-members-modal.tsx
- Thêm function formatFacebookUrl() để format URL
- Sửa hiển thị từ 'Facebook' thành formatFacebookUrl(member.facebook_link)
- Thêm title attribute cho tooltip

### components/admin/teams/team-detail-modal.tsx
- Thêm function formatFacebookUrl() để format URL
- Sửa hiển thị từ 'Facebook' thành formatFacebookUrl(member.facebook_link)  
- Thêm title attribute cho tooltip
- Giữ nguyên icon 📘 và style

## Lợi ích

1. **Dễ nhận biết**: User có thể thấy URL chi tiết thay vì text generic
2. **Dễ sao chép**: Tooltip hiển thị URL đầy đủ để sao chép
3. **UX tốt hơn**: Truncate URL dài để không vỡ layout
4. **Nhất quán**: Style và behavior nhất quán giữa các modal

Closes #NEW