### PR TITLE
Sửa lỗi tải lại trang khi quản lý thành viên đội

### DIFF
--- a/components/admin/teams/manage-team-members-modal.tsx
+++ b/components/admin/teams/manage-team-members-modal.tsx
@@ -99,11 +99,11 @@ interface UnassignedRegistrant {
 interface ManageTeamMembersModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onDataChange?: () => void; // New callback for data changes without closing dialog
+  onMemberCountChange?: (teamId: string, newCount: number) => void; // Callback to update member count only
   team: Team | null;
 }
 
-export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: ManageTeamMembersModalProps) {
+export function ManageTeamMembersModal({ isOpen, onClose, onMemberCountChange, team }: ManageTeamMembersModalProps) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [unassignedRegistrants, setUnassignedRegistrants] = useState<UnassignedRegistrant[]>([]);
   const [isLoadingMembers, setIsLoadingMembers] = useState(false);
@@ -228,8 +228,16 @@ export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: 
       await Promise.all([fetchTeamMembers(), fetchUnassignedRegistrants()]);
       toast.success("Thêm thành viên thành công!");
 
-      // Notify parent component about data change without closing dialog
-      onDataChange?.();
+      // Update member count in parent component without full refresh
+      // Use the updated members count after fetch
+      if (team && onMemberCountChange) {
+        // Fetch the updated member count from the API response
+        const response = await fetch(`/api/admin/teams/${team.id}/members`);
+        if (response.ok) {
+          const data = await response.json();
+          onMemberCountChange(team.id, data.member_count || data.members?.length || 0);
+        }
+      }
     } catch (error) {
       console.error("Error adding member:", error);
 
@@ -289,8 +297,16 @@ export function ManageTeamMembersModal({ isOpen, onClose, onDataChange, team }: 
       await Promise.all([fetchTeamMembers(), fetchUnassignedRegistrants()]);
       toast.success("Xóa thành viên thành công!");
 
-      // Notify parent component about data change without closing dialog
-      onDataChange?.();
+      // Update member count in parent component without full refresh
+      // Use the updated members count after fetch
+      if (team && onMemberCountChange) {
+        // Fetch the updated member count from the API response
+        const response = await fetch(`/api/admin/teams/${team.id}/members`);
+        if (response.ok) {
+          const data = await response.json();
+          onMemberCountChange(team.id, data.member_count || data.members?.length || 0);
+        }
+      }
     } catch (error) {
       console.error("Error removing member:", error);
 

--- a/components/admin/teams/team-management-tab.tsx
+++ b/components/admin/teams/team-management-tab.tsx
@@ -300,9 +300,15 @@ export function TeamManagementTab() {
       <ManageTeamMembersModal
         isOpen={!!manageTeam}
         onClose={() => setManageTeam(null)}
-        onDataChange={() => {
-          // Refresh teams data without closing dialog
-          fetchTeams();
+        onMemberCountChange={(teamId, newCount) => {
+          // Update only the member count for the specific team without full refresh
+          setTeams(prevTeams =>
+            prevTeams.map(team =>
+              team.id === teamId
+                ? { ...team, member_count: newCount }
+                : team
+            )
+          );
         }}
         team={manageTeam}
       />


### PR DESCRIPTION
## Mô tả

Sửa lỗi khi thêm hoặc xóa thành viên vào đội có hiện tượng tải lại cửa sổ không cần thiết.

## Thay đổi

- Thay thế callback `onDataChange` bằng `onMemberCountChange` để chỉ cập nhật số lượng thành viên
- Loại bỏ việc tải lại toàn bộ danh sách đội khi thêm/xóa thành viên
- Modal đã có optimistic updates và tự refresh data nội bộ
- Cập nhật số lượng thành viên chính xác từ API response

## Test

- [x] Build thành công
- [x] Không có lỗi TypeScript
- [x] Logic optimistic updates hoạt động đúng
- [x] Callback cập nhật số lượng thành viên chính xác

Closes #182

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author