### PR TITLE
Thiết lập default sức chứa đội là 50

### DIFF
--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -123,7 +123,7 @@ export async function POST(request: NextRequest) {
         event_config_id,
         leader_id,
         sub_leader_id,
-        capacity: capacity || null,
+        capacity: capacity || 50,
       })
       .select(`
         *,

--- a/components/admin/teams/create-team-modal.tsx
+++ b/components/admin/teams/create-team-modal.tsx
@@ -79,7 +79,7 @@ export function CreateTeamModal({ isOpen, onClose, onSuccess }: CreateTeamModalP
       description: "",
       leader_id: "",
       sub_leader_id: "",
-      capacity: "",
+      capacity: "50",
     },
   });
 
@@ -135,7 +135,7 @@ export function CreateTeamModal({ isOpen, onClose, onSuccess }: CreateTeamModalP
           event_config_id: activeEventId,
           leader_id: data.leader_id === "none" ? null : data.leader_id || null,
           sub_leader_id: data.sub_leader_id === "none" ? null : data.sub_leader_id || null,
-          capacity: data.capacity && data.capacity !== "" ? parseInt(data.capacity, 10) : null,
+          capacity: data.capacity && data.capacity !== "" ? parseInt(data.capacity, 10) : 50,
         }),
       });
 
@@ -243,11 +243,11 @@ export function CreateTeamModal({ isOpen, onClose, onSuccess }: CreateTeamModalP
               id="capacity"
               type="number"
               min="1"
-              placeholder="Để trống nếu không giới hạn"
+              placeholder="50"
               {...register("capacity")}
             />
             <p className="text-sm text-muted-foreground">
-              Số lượng thành viên tối đa trong đội. Để trống nếu không giới hạn.
+              Số lượng thành viên tối đa trong đội. Mặc định là 50 người.
             </p>
             {errors.capacity && (
               <p className="text-sm text-red-500">{errors.capacity.message}</p>


### PR DESCRIPTION
## Mô tả

Thiết lập default sức chứa mỗi đội là 50 nếu không nhập gì hết.

## Thay đổi chính

### 📊 Form tạo đội
- **Default value**: Thay đổi từ "" (rỗng) thành "50"
- **Placeholder**: Cập nhật từ "Để trống nếu không giới hạn" thành "50"
- **Description**: Cập nhật thành "Số lượng thành viên tối đa trong đội. Mặc định là 50 người."

### 💻 Logic xử lý
- **Frontend**: Nếu capacity rỗng thì dùng 50 thay vì null
- **Backend API**: Nếu capacity rỗng thì lưu 50 thay vì null

## Trước và sau

### Trước:
- Không nhập sức chứa → capacity = null (không giới hạn)
- Placeholder: "Để trống nếu không giới hạn"
- Description: "Số lượng thành viên tối đa trong đội. Để trống nếu không giới hạn."

### Sau:
- Không nhập sức chứa → capacity = 50 (mặc định)
- Form hiển thị sẵn giá trị 50
- Placeholder: "50"
- Description: "Số lượng thành viên tối đa trong đội. Mặc định là 50 người."

## Files thay đổi

1. **`components/admin/teams/create-team-modal.tsx`**:
   - Thay đổi defaultValues capacity: "" → "50"
   - Cập nhật placeholder và description
   - Cập nhật logic xử lý: rỗng → 50

2. **`app/api/admin/teams/route.ts`**:
   - Thay đổi logic API: `capacity || null` → `capacity || 50`

## Lưu ý

- **EditTeamModal không thay đổi**: Vì đây là chỉnh sửa đội cũ, không cần default
- **Validation giữ nguyên**: Vẫn cho phép nhập số khác nếu muốn
- **Tương thích ngược**: Đội cũ với capacity = null vẫn hoạt động bình thường

## Test

- [x] Build thành công
- [x] Không có lỗi TypeScript
- [x] Form hiển thị default 50
- [x] API lưu capacity = 50 khi không nhập
- [x] Vẫn cho phép nhập giá trị khác
- [x] Validation hoạt động đúng

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author