### PR TITLE
fix: thống nhất quyền hạn team management cho registration_manager

### DIFF
--- a/app/api/admin/teams/[id]/members/route.ts
+++ b/app/api/admin/teams/[id]/members/route.ts
@@ -97,7 +97,7 @@ export async function POST(
       .eq("id", user.id)
       .single();
 
-    if (!profile || !["event_organizer", "regional_admin", "super_admin"].includes(profile.role)) {
+    if (!profile || !["event_organizer", "registration_manager", "regional_admin", "super_admin"].includes(profile.role)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -194,7 +194,7 @@ export async function DELETE(
       .eq("id", user.id)
       .single();
 
-    if (!profile || !["event_organizer", "regional_admin", "super_admin"].includes(profile.role)) {
+    if (!profile || !["event_organizer", "registration_manager", "regional_admin", "super_admin"].includes(profile.role)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    if (!profile || !["event_organizer", "regional_admin", "super_admin"].includes(profile.role)) {
+    if (!profile || !["event_organizer", "registration_manager", "regional_admin", "super_admin"].includes(profile.role)) {
       return NextResponse.json({ error: "Không có quyền thực hiện thao tác này" }, { status: 403 });
     }
 
@@ -161,7 +161,7 @@ export async function PUT(request: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    if (!profile || !["event_organizer", "regional_admin", "super_admin"].includes(profile.role)) {
+    if (!profile || !["event_organizer", "registration_manager", "regional_admin", "super_admin"].includes(profile.role)) {
       return NextResponse.json({ error: "Không có quyền thực hiện thao tác này" }, { status: 403 });
     }
 
@@ -235,7 +235,7 @@ export async function DELETE(request: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    if (!profile || !["event_organizer", "regional_admin", "super_admin"].includes(profile.role)) {
+    if (!profile || !["event_organizer", "registration_manager", "regional_admin", "super_admin"].includes(profile.role)) {
       return NextResponse.json({ error: "Không có quyền thực hiện thao tác này" }, { status: 403 });
     }
 


### PR DESCRIPTION
## Mô tả thay đổi

Thống nhất quyền hạn team management cho role `registration_manager` để đảm bảo tính nhất quán: **bất kỳ admin nào có thể xem chức năng phân đội thì cũng có thể thêm/xóa/sửa thành viên của đội**.

## Vấn đề trước đây

Role `registration_manager` có thể:
- ✅ Xem danh sách teams
- ✅ Xem thành viên của đội
- ❌ **KHÔNG THỂ** thêm thành viên vào đội
- ❌ **KHÔNG THỂ** xóa thành viên khỏi đội
- ❌ **KHÔNG THỂ** tạo/sửa/xóa team

## Giải pháp

Thêm `registration_manager` vào danh sách các role được phép trong tất cả các API endpoints liên quan đến team management:

### Các API được cập nhật:

1. **API DELETE thành viên khỏi đội** (`/api/admin/teams/[id]/members`)
2. **API POST thêm thành viên vào đội** (`/api/admin/teams/[id]/members`)
3. **API POST tạo team mới** (`/api/admin/teams`)
4. **API PUT sửa thông tin team** (`/api/admin/teams`)
5. **API DELETE xóa team** (`/api/admin/teams`)

### Kết quả sau khi cập nhật:

Role `registration_manager` giờ đây có thể:
- ✅ Xem danh sách teams
- ✅ Xem thành viên của đội
- ✅ **Thêm thành viên vào đội**
- ✅ **Xóa thành viên khỏi đội**
- ✅ **Tạo team mới**
- ✅ **Sửa thông tin team**
- ✅ **Xóa team**

## Testing

Đã test thành công tất cả chức năng với role `registration_manager`:

✅ **API DELETE thành viên khỏi đội** - Thành công  
✅ **API POST thêm thành viên vào đội** - Thành công  
✅ **API POST tạo team mới** - Thành công  
✅ **API PUT sửa thông tin team** - Thành công  
✅ **API DELETE xóa team** - Thành công  
✅ **Lint & Build** - Thành công

## Files Changed

- `app/api/admin/teams/[id]/members/route.ts` - Thêm `registration_manager` vào API POST và DELETE
- `app/api/admin/teams/route.ts` - Thêm `registration_manager` vào API POST, PUT, DELETE

Closes #246

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author