### PR TITLE
fix: remove same registration constraint in team assignment

### DIFF
--- a/app/api/admin/registrants/[id]/assign-team/route.ts
+++ b/app/api/admin/registrants/[id]/assign-team/route.ts
@@ -66,45 +66,7 @@ export async function POST(
       }, { status: 400 });
     }
 
-    // Check for other registrants with the same registration code
-    const registration = Array.isArray(registrant.registration)
-      ? registrant.registration[0]
-      : registrant.registration;
 
-    if (!registration) {
-      return NextResponse.json({ error: "Registration not found" }, { status: 404 });
-    }
-
-    const registrationId = registration.id;
-    const invoiceCode = registration.invoice_code;
-
-    const { data: sameRegistrationRegistrants, error: sameRegError } = await supabase
-      .from("registrants")
-      .select(`
-        id,
-        full_name,
-        event_team_id
-      `)
-      .eq("registration_id", registrationId)
-      .neq("id", registrantId); // Exclude current registrant
-
-    if (sameRegError) {
-      console.error("Error fetching same registration registrants:", sameRegError);
-    }
-
-    // Check if any of the same registration registrants are unassigned
-    const unassignedSameReg = sameRegistrationRegistrants?.filter(r => !r.event_team_id) || [];
-
-    if (unassignedSameReg.length > 0) {
-      return NextResponse.json({
-        error: `Có ${unassignedSameReg.length} người khác cùng đăng ký ${invoiceCode} chưa được phân đội. Vui lòng phân đội tất cả cùng lúc để đảm bảo họ ở cùng một đội.`,
-        suggestion: "bulk_assign",
-        same_registration_registrants: unassignedSameReg.map(r => ({
-          id: r.id,
-          name: r.full_name
-        }))
-      }, { status: 400 });
-    }
 
     // Validate team exists and get capacity info
     const { data: team, error: teamError } = await supabase


### PR DESCRIPTION
Bỏ logic ràng buộc yêu cầu tất cả người trong cùng registration phải được phân đội cùng lúc.

## Thay đổi
- Xóa logic kiểm tra người khác cùng registration chưa được phân đội
- Cho phép admin phân đội cho từng người độc lập
- Người trong cùng registration có thể ở các đội khác nhau

## Test
- ✅ API hoạt động bình thường
- ✅ Có thể phân đội độc lập cho từng người
- ✅ Lint và build thành công
- ✅ Test bằng browser thành công

Closes #001