### PR TITLE
fix: enhance search functionality in teams assignment

### DIFF
--- a/components/admin/teams/unassigned-registrants-list.tsx
+++ b/components/admin/teams/unassigned-registrants-list.tsx
@@ -233,7 +233,7 @@ export function UnassignedRegistrantsList() {
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
-                  placeholder="Tìm kiếm theo tên..."
+                  placeholder="Tìm kiếm theo tên hoặc mã đăng ký..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10"


### PR DESCRIPTION
Khắc phục hai vấn đề trong trang admin phân đội:

## 🐛 Vấn đề đã khắc phục

### 1. Lỗi tải danh sách khi tìm kiếm
- **Vấn đề:** API trả về lỗi 500 khi sử dụng tìm kiếm trong tab "Chưa phân đội"
- **Nguyên nhân:** Cú pháp PostgREST .or() không đúng với nested field queries
- **Giải pháp:** Sử dụng separate queries và combine kết quả để tránh parsing issues

### 2. Mở rộng tính năng tìm kiếm
- **Trước:** Chỉ tìm kiếm theo tên người tham dự
- **Sau:** Hỗ trợ tìm kiếm cả tên và mã đăng ký (invoice code)
- **Ví dụ:** Có thể tìm "#DH25-050367", "#INV-2025-308110" hoặc "Nguyễn Văn A"

## 🔧 Thay đổi kỹ thuật

### API Changes ()
- Thay thế complex OR query bằng separate queries cho name và invoice code
- Combine kết quả từ cả hai searches để tránh PostgREST parsing errors
- Áp dụng cùng logic cho cả main query và count query để đảm bảo pagination chính xác

### Frontend Changes ()
- Cập nhật placeholder: "Tìm kiếm theo tên hoặc mã đăng ký..."
- Không thay đổi logic frontend, chỉ cập nhật UI text

## ✅ Test Results

### Trước khi sửa:
- ❌ Tìm kiếm theo tên: Lỗi 500 "Failed to fetch registrants"
- ❌ Tìm kiếm theo mã đăng ký: Không hỗ trợ

### Sau khi sửa:
- ✅ Tìm kiếm theo tên: Hoạt động bình thường
- ✅ Tìm kiếm theo mã đăng ký: Hoạt động bình thường  
- ✅ Tìm kiếm kết hợp: Hỗ trợ cả tên và mã đăng ký
- ✅ Không có lỗi console
- ✅ Lint và build thành công

## 🎯 Impact
- Cải thiện trải nghiệm admin khi quản lý phân đội
- Tăng hiệu quả tìm kiếm với nhiều tiêu chí hơn
- Khắc phục lỗi nghiêm trọng trong tính năng core

Closes #002