### PR TITLE
fix: resolve avatar zoom inconsistency in ticket export

### DIFF
--- a/components/tickets/ticket-generator.tsx
+++ b/components/tickets/ticket-generator.tsx
@@ -46,13 +46,24 @@ export function TicketGenerator({ registrant }: TicketGeneratorProps) {
 
   const handleSaveTicket = () => {
     if (typeof window !== 'undefined' && ticketRef.current) {
-      html2canvas(ticketRef.current, { useCORS: true }).then(canvas => {
+      html2canvas(ticketRef.current, {
+        useCORS: true,
+        allowTaint: true,
+        scale: 2, // Higher resolution
+        backgroundColor: '#ffffff',
+        logging: false,
+        imageTimeout: 15000,
+        removeContainer: true
+      }).then(canvas => {
         const link = document.createElement('a');
-        link.href = canvas.toDataURL('image/png');
+        link.href = canvas.toDataURL('image/png', 1.0); // Max quality
         link.download = `DaiHoiCongGiao2025-Ticket-${registrant.id}.png`;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
+      }).catch(error => {
+        console.error('Error generating ticket image:', error);
+        alert('Có lỗi xảy ra khi tạo ảnh vé. Vui lòng thử lại.');
       });
     }
   };
@@ -66,14 +77,16 @@ export function TicketGenerator({ registrant }: TicketGeneratorProps) {
         <CardContent className="p-6">
           <div className="flex flex-col items-center space-y-4">
             {registrant.portrait_url && (
-              <div className="size-48 rounded-full overflow-hidden border-4 border-gray-200">
+              <div className="size-48 rounded-full overflow-hidden border-4 border-gray-200 bg-gray-100">
                 <Image
                   src={registrant.portrait_url}
                   alt="Portrait"
-                  width={128}
-                  height={128}
-                  className="object-fill w-full h-full"
+                  width={192}
+                  height={192}
+                  className="object-cover w-full h-full"
                   crossOrigin="anonymous"
+                  priority
+                  unoptimized
                 />
               </div>
             )}


### PR DESCRIPTION
## 🐛 Mô tả vấn đề

Avatar trong ticket export bị zoom/scale khác so với preview trên màn hình, gây ra sự không nhất quán trong trải nghiệm người dùng.

## ✅ Giải pháp

### **Cải thiện html2canvas options:**
- ✅ Tăng `scale: 2` để có độ phân giải cao hơn
- ✅ Thêm `allowTaint: true` để xử lý CORS images
- ✅ Tăng `imageTimeout: 15000` để đợi ảnh load
- ✅ Thêm error handling cho trường hợp export thất bại
- ✅ Sử dụng `canvas.toDataURL('image/png', 1.0)` cho chất lượng tối đa

### **Sửa avatar display:**
- ✅ Đổi từ `object-fill` → `object-cover` (chuẩn hơn)
- ✅ Đổi kích thước từ `128x128` → `192x192` (khớp với `size-48`)
- ✅ Thêm `priority` và `unoptimized` cho Next.js Image
- ✅ Thêm `bg-gray-100` làm background

## 🧪 Test

- [x] Avatar preview và export hiển thị nhất quán
- [x] Chất lượng ảnh export được cải thiện
- [x] Error handling hoạt động đúng
- [x] Không ảnh hưởng đến các tính năng khác

## 📁 Files thay đổi

- `components/tickets/ticket-generator.tsx`: Cải thiện logic export và avatar display

---

**Fixes:** Avatar zoom inconsistency between preview and export in ticket generation

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author